### PR TITLE
Retrieve ref content by its unique name and commit checksum

### DIFF
--- a/tests/scripts/pulp_ostree/test_import_publish.sh
+++ b/tests/scripts/pulp_ostree/test_import_publish.sh
@@ -6,6 +6,7 @@
 cleanup() {
   pulp ostree repository destroy --name "cli_test_ostree_repository" || true
   pulp ostree distribution destroy --name "cli_test_ostree_distro" || true
+  pulp orphan cleanup || true
 }
 trap cleanup EXIT
 

--- a/tests/scripts/pulp_ostree/test_modify_content.sh
+++ b/tests/scripts/pulp_ostree/test_modify_content.sh
@@ -7,6 +7,7 @@ cleanup() {
   pulp ostree repository destroy --name "cli_test_ostree_repository1" || true
   pulp ostree repository destroy --name "cli_test_ostree_repository2" || true
   pulp ostree remote destroy --name "cli_test_ostree_remote" || true
+  pulp orphan cleanup || true
 }
 trap cleanup EXIT
 
@@ -18,19 +19,47 @@ expect_succ pulp ostree repository sync --name "cli_test_ostree_repository1" \
 expect_succ pulp ostree repository create --name "cli_test_ostree_repository2"
 
 # add content to the second repository
-expect_succ pulp ostree repository content add --repository "cli_test_ostree_repository2" \
-  --commit "506f7811e94cb0966ada5f52a60eb4c34e534037497390ec4491712c3b040938"
-expect_succ pulp ostree repository content add --repository "cli_test_ostree_repository2" \
-  --ref "stable"
+expect_succ pulp ostree repository commit add --repository "cli_test_ostree_repository2" \
+  --checksum "506f7811e94cb0966ada5f52a60eb4c34e534037497390ec4491712c3b040938"
+expect_succ pulp ostree repository ref add --repository "cli_test_ostree_repository2" \
+  --name "stable" \
+  --checksum "7f92632aa5a71a0a36ff97ae14dd298081d52aaa8fa1cd79fb19521e00c35030"
 
-# remove the added content from the repository
-expect_succ pulp ostree repository content remove --repository "cli_test_ostree_repository2" \
-  --commit "506f7811e94cb0966ada5f52a60eb4c34e534037497390ec4491712c3b040938"
-expect_succ pulp ostree repository content remove --repository "cli_test_ostree_repository2" \
-  --ref "stable"
+# remove the added content from the second repository
+expect_succ pulp ostree repository commit remove --repository "cli_test_ostree_repository2" \
+  --checksum "506f7811e94cb0966ada5f52a60eb4c34e534037497390ec4491712c3b040938"
+expect_succ pulp ostree repository ref remove --repository "cli_test_ostree_repository2" \
+  --name "stable" \
+  --checksum "7f92632aa5a71a0a36ff97ae14dd298081d52aaa8fa1cd79fb19521e00c35030"
 
-# list content stored within the latest versions of the repositories
+# remove the original content from the first repository
+expect_succ pulp ostree repository commit remove --repository "cli_test_ostree_repository1" \
+  --checksum "506f7811e94cb0966ada5f52a60eb4c34e534037497390ec4491712c3b040938"
+expect_succ pulp ostree repository ref remove --repository "cli_test_ostree_repository1" \
+  --name "stable" \
+  --checksum "7f92632aa5a71a0a36ff97ae14dd298081d52aaa8fa1cd79fb19521e00c35030"
+
+# add the content back to the first repository
+expect_succ pulp ostree repository commit add --repository "cli_test_ostree_repository1" \
+  --checksum "506f7811e94cb0966ada5f52a60eb4c34e534037497390ec4491712c3b040938"
+expect_succ pulp ostree repository ref add --repository "cli_test_ostree_repository1" \
+  --name "stable" \
+  --checksum "7f92632aa5a71a0a36ff97ae14dd298081d52aaa8fa1cd79fb19521e00c35030"
+
+# list content stored within the latest repository versions
+expect_succ pulp ostree repository ref list --repository "cli_test_ostree_repository1"
+expect_succ pulp ostree repository ref list --repository "cli_test_ostree_repository1" \
+  --type "ref"
+
+expect_succ pulp ostree repository commit list --repository "cli_test_ostree_repository1"
+expect_succ pulp ostree repository commit list --repository "cli_test_ostree_repository1" \
+  --type "commit"
+
+expect_succ pulp ostree repository content list --repository "cli_test_ostree_repository1"
+
 expect_succ pulp ostree repository content list --repository "cli_test_ostree_repository1" \
   --type "all"
-expect_succ pulp ostree repository content list --repository "cli_test_ostree_repository2" \
+expect_succ pulp ostree repository content list --repository "cli_test_ostree_repository1" \
+  --type "ref"
+expect_succ pulp ostree repository content list --repository "cli_test_ostree_repository1" \
   --type "commit"

--- a/tests/scripts/pulp_ostree/test_sync_publish.sh
+++ b/tests/scripts/pulp_ostree/test_sync_publish.sh
@@ -7,6 +7,7 @@ cleanup() {
   pulp ostree remote destroy --name "cli_test_ostree_remote" || true
   pulp ostree repository destroy --name "cli_test_ostree_repository" || true
   pulp ostree distribution destroy --name "cli_test_ostree_distro" || true
+  pulp orphan cleanup || true
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
Before this commit, OSTree content could be added/removed via the content command in the following format:
```
pulp ostree repository content add --repository "ostree_repository" \
  --commit "506f7811e94cb0966ada5f52a60eb4c34e534037497390ec4491712c3b040938"
pulp ostree repository content add --repository "ostree_repository" \
  --ref "stable"
```

Now, the content can be added/removed by issuing the following commands:
```
pulp ostree repository commit add --repository "ostree_repository" \
  --commit "506f7811e94cb0966ada5f52a60eb4c34e534037497390ec4491712c3b040938"
pulp ostree repository ref add --repository "ostree_repository" \
  --name "stable" \
  --checksum "7f92632aa5a71a0a36ff97ae14dd298081d52aaa8fa1cd79fb19521e00c35030"
```